### PR TITLE
Float error

### DIFF
--- a/slipscheme.go
+++ b/slipscheme.go
@@ -357,7 +357,7 @@ func (s *SchemaProcessor) processSchema(schema *Schema) (typeName string, err er
 	} else if schema.Type == INTEGER {
 		typeName = "int"
 	} else if schema.Type == NUMBER {
-		typeName = "float"
+		typeName = "float64"
 	} else if schema.Type == NULL || schema.Type == ANY {
 		typeName = "interface{}"
 	} else if schema.Type == STRING {


### PR DESCRIPTION
Go Version: 1.10

In `slipschema.go` line 359 - 360 
```
else if schema.Type == NUMBER {
	typeName = "float"
```
In Go 1.10 float is not a type. I propose this should be changed to float64 (or float32) so that the generated go structs can successfully build. 
